### PR TITLE
Lock system independent of display manager

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,8 +92,9 @@ fn lock_system() {
             .output()
             .expect("Failed to lock workstation");
     } else if cfg!(target_os = "linux") {
-        Command::new("gnome-screensaver-command")
-            .arg("-l")
+        Command::new("systemctl")
+            .arg("restart")
+            .arg("display-manager")
             .output()
             .expect("Failed to lock screen");
     } else if cfg!(target_os = "macos") {


### PR DESCRIPTION
Restart the display manager service so that you can lock the system independent of your display manager